### PR TITLE
Optimize card grid

### DIFF
--- a/src/components/shared/PracticeCards/PracticeCardGrid.js
+++ b/src/components/shared/PracticeCards/PracticeCardGrid.js
@@ -13,7 +13,7 @@ const PracticeCardGrid = (props) => {
 
   function handleScroll() {
     if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight || !props.onLoadMore) return;
-    page = page + 8;
+    page = page + 12;
     props.onLoadMore(page);
   }
 

--- a/src/pages/Practices.js
+++ b/src/pages/Practices.js
@@ -47,7 +47,7 @@ export default function Practices(props) {
     {
       variables: {
         start: 0,
-        limit: 8
+        limit: 12
       },
       fetchPolicy: "cache-and-network"
     }

--- a/src/pages/__tests__/Practices.js
+++ b/src/pages/__tests__/Practices.js
@@ -49,7 +49,7 @@ const apolloMocks = [
       query: GET_PRACTICES,
       variables: {
         start: 0,
-        limit: 8
+        limit: 12
       }
     },
     result: { data: { practices: mockPracticeData } }

--- a/src/router/OPLRouter.js
+++ b/src/router/OPLRouter.js
@@ -1,10 +1,31 @@
 import React from "react";
-import { Router } from "@reach/router";
+import { Router, Location } from "@reach/router";
 import { useQuery } from "@apollo/react-hooks";
 
 import LoginContext from '../components/shared/Login/LoginContext';
 import { HomePage, PracticesPage, PracticePageContentPage } from "../pages";
 import { currentUserQuery } from "../graphql";
+
+/* Somewhat hacky workaround the scroll position problem
+ * https://stackoverflow.com/questions/53058110/stop-reach-router-scrolling-down-the-page-after-navigating-to-new-page
+ */
+class OnRouteChangeWorker extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      this.props.action()
+    }
+  }
+
+  render() {
+    return null
+  }
+}
+
+const OnRouteChange = ({ action }) => (
+  <Location>
+    {({ location }) => <OnRouteChangeWorker location={location} action={action} />}
+  </Location>
+)
 
 const OPLRouter = (props) => {
   const { data: loggedIn } = useQuery(currentUserQuery);
@@ -16,6 +37,7 @@ const OPLRouter = (props) => {
         <PracticesPage path="/practice"/>
         <PracticePageContentPage path="/practice/:name"/>
       </Router>
+      <OnRouteChange action={() => window.scrollTo(0, 0) } />
     </LoginContext.Provider>
   );
 };


### PR DESCRIPTION
Resolves #59 
Paginating card grid by 12 instead of 8; implemented scrollToTop to avoid SPA problems.

SPA problems reference this flow:
- Scroll down on any page, click a link to another page.
- The scroll position remains the same

This is an issue specific to the card grid, as pagination/lazy loading is triggered by scroll position. When entering the card grid at a lower scroll position, the query that is triggered may skip several practices, rendering an inconsistent library. With scrollToTop, every page change will start at the top of the page.