### PR TITLE
Activated About page link in drawer

### DIFF
--- a/src/components/shared/Drawer/ListItems.js
+++ b/src/components/shared/Drawer/ListItems.js
@@ -98,9 +98,7 @@ export function BottomListItems() {
       <ListSubheader>
         <Typography variant="overline" className={classes.headers}>Community</Typography>
       </ListSubheader>
-      <ListItem button>
-        <Typography variant="body2"> Learn about us </Typography>
-      </ListItem>
+      <ListItemLink to="/about" primary="Learn about us" data-testid="LearnAboutUs"/>
     </List>
   );
 }


### PR DESCRIPTION
Resolves #133 

As @piyushsn and I were merging our changes, we found a spot where drawer links were re-arranged and we had missed a spot where the original About Us link had been removed in designs, but the new "Learn about us" link in the drawer wasn't activated yet in code.  This commit fixes that.